### PR TITLE
feat: new title arg in Page to override label in select

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ This is an individual page to be added to the paginator.
 
 - `?content: str`: The content of the page.
 - `?embeds: Embed | list[Embed]`: The embed(s) to be displayed on the page.
+- `?title: str`: The title of the page displayed in the select menu.
+  - Defaults to content or the title of the embed with an available title.
 
 ### Example
 

--- a/interactions/ext/paginator/extension.py
+++ b/interactions/ext/paginator/extension.py
@@ -1,7 +1,7 @@
 from interactions.ext import Base, Version, VersionAuthor
 
 version: Version = Version(
-    version="2.0.1",
+    version="2.0.2",
     author=VersionAuthor(
         name="Toricane",
         email="prjwl028@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="dinteractions_Paginator",
-    version="2.0.1",
+    version="2.0.2",
     description="Official interactions.py paginator",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## About

This pull request adds support for overriding the label in select options of the select menu.
Example:
```py
@bot.command(name="paginator", description="Paginator example", scope=924871439776108544)
async def paginator_example(ctx: CommandContext):
    await Paginator(
        client=bot,
        ctx=ctx,
        pages=[
            Page(embeds=Embed(description="no title lol")),
            Page(embeds=Embed(description="no title but shows 'hello' in label"), title="hello"),
        ],
    ).run()
```

## Checklist

- [x] I've ran `pre-commit` to format and lint the change(s) made.
- [x] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [x] Documentation
  - [ ] Breaking change
  - [x] New feature/enhancement
  - [ ] Bugfix
