### PR TITLE
Add delete button functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ await p.run()
     - To modify this behavior, modify `disable_after_timeout` or `remove_after_timeout`.
 - `?author_only: bool = False`: Whether the paginator should only be used by the author.
 - `?use_buttons: bool = True`: Whether the paginator should use buttons.
+- `?use_delete_button: bool = True`: Whether the paginator include a delete button that deletes the original message.  Cannot be used when `use_index` is enabled.
 - `?use_select: bool = True`: Whether the paginator should use the select menu.
 - `?use_index: bool = False`: Whether the paginator should use the index button.
 - `?extended_buttons: bool = True`: Whether the paginator should use extended buttons.
@@ -208,6 +209,7 @@ Additional attributes:
 - `INDEX: "index"`: The index button.
 - `NEXT: "next"`: The next button.
 - `LAST: "last"`: The last button.
+- `DELETE: "delete"`: The delete button.
 
 ------------------------------
 


### PR DESCRIPTION
## About

This PR adds a new feature that gives users the ability to delete a paginator and it's parent message upon clicking a `delete` button. This feature is only available if `use_index` is disabled (due to limit of 5 buttons per row).  See screenshot below for an example of how it looks.  Please let me know if you have any feedback. Thank you.

![image](https://user-images.githubusercontent.com/4008256/208285358-d5fb64bc-b2cf-4c5e-9da1-609aa560d866.png)


## Checklist

- [ ] I've ran `pre-commit` to format and lint the change(s) made.
- [ ] I've checked to make sure the change(s) work on `3.8.6` and higher.
- [ ] This fixes/solves an [Issue](https://github.com/goverfl0w/discord-interactions/issues).
  - (If existent):
- [ ] I've made this pull request for/as: (check all that apply)
  - [ ] Documentation
  - [ ] Breaking change
  - [ ] New feature/enhancement
  - [ ] Bugfix
